### PR TITLE
Fix mingw compilation.

### DIFF
--- a/SDL2pp/RWops.cc
+++ b/SDL2pp/RWops.cc
@@ -190,8 +190,8 @@ Sint64 RWops::Tell() {
 
 Sint64 RWops::Size() {
 	Sint64 old_pos = Tell();
-	Sint64 size = Seek(0, SEEK_END);
-	Sint64 back_pos = Seek(old_pos, SEEK_SET);
+	Sint64 size = Seek(0, RW_SEEK_END);
+	Sint64 back_pos = Seek(old_pos, RW_SEEK_SET);
 	(void)back_pos; // silence unused variable warning on release build
 	assert(back_pos == old_pos);
 	return size;


### PR DESCRIPTION
SEEK_END and SEEK_SET are not visible for mingw (there is no #include \<stdio.h\> in the include tree for SDLpp/RWops.cc).
Both constants are used in RWops::Seek -> SDL_RWseek, which accepts "whence" as one of defines RW_SEEK_SET/RW_SEEK_CUR/RW_SEEK_END.
My suggestion is: replace SEEK_END -> RW_SEEK_END, SEEK_SET -> RW_SEEK_SET.