### PR TITLE
Missed Font::IsGlyphProvided definition has been added. Removed extra pixels from Font::GetGlyphRect().

### DIFF
--- a/SDL2pp/Font.cc
+++ b/SDL2pp/Font.cc
@@ -140,6 +140,10 @@ Optional<std::string> Font::GetStyleName() const {
 	return std::string(str);
 }
 
+int Font::IsGlyphProvided(Uint16 ch) const {
+	return TTF_GlyphIsProvided(font_, ch);
+}
+
 void Font::GetGlyphMetrics(Uint16 ch, int& minx, int& maxx, int& miny, int& maxy, int& advance) const {
 	if (TTF_GlyphMetrics(font_, ch, &minx, &maxx, &miny, &maxy, &advance) != 0)
 		throw Exception("TTF_GlyphMetrics");

--- a/SDL2pp/Font.cc
+++ b/SDL2pp/Font.cc
@@ -153,7 +153,7 @@ Rect Font::GetGlyphRect(Uint16 ch) const {
 	int minx, maxx, miny, maxy;
 	if (TTF_GlyphMetrics(font_, ch, &minx, &maxx, &miny, &maxy, nullptr) != 0)
 		throw Exception("TTF_GlyphMetrics");
-	return Rect(minx, miny, maxx - minx + 1, maxy - miny + 1);
+	return Rect(minx, miny, maxx - minx, maxy - miny);
 }
 
 int Font::GetGlyphAdvance(Uint16 ch) const {


### PR DESCRIPTION
from SDL_ttf.c
```
cached->minx = FT_FLOOR(metrics->horiBearingX);
cached->maxx = FT_CEIL(metrics->horiBearingX + metrics->width);
```
I think there are extra pixels when they calc rect width and height:
```
return Rect(minx, miny, maxx - minx + 1, maxy - miny + 1);
```


