### PR TITLE
Added GetDrawableWidth and GetDrawableHeight for HiDPI support

### DIFF
--- a/SDL2pp/Window.cc
+++ b/SDL2pp/Window.cc
@@ -76,6 +76,24 @@ int Window::GetHeight() const {
 	return h;
 }
 
+Point Window::GetDrawableSize() const {
+	int w, h;
+	SDL_GL_GetDrawableSize(window_, &w, &h);
+	return Point(w, h);
+}
+
+int Window::GetDrawableWidth() const {
+	int w, h;
+	SDL_GL_GetDrawableSize(window_, &w, &h);
+	return w;
+}
+
+int Window::GetDrawableHeight() const {
+	int w, h;
+	SDL_GL_GetDrawableSize(window_, &w, &h);
+	return h;
+}
+
 Window& Window::SetTitle(const std::string& title) {
 	SDL_SetWindowTitle(window_, title.c_str());
 	return *this;

--- a/SDL2pp/Window.hh
+++ b/SDL2pp/Window.hh
@@ -174,6 +174,37 @@ public:
 	int GetHeight() const;
 
 	////////////////////////////////////////////////////////////
+	/// \brief Get drawable dimensions of the window
+	///
+	/// \returns SDL2pp::Point representing dimensions (width and
+	///          height) of the window in pixels
+	///
+	/// \see http://wiki.libsdl.org/SDL_GL_GetDrawableSize
+	///
+	////////////////////////////////////////////////////////////
+	Point GetDrawableSize() const;
+
+	////////////////////////////////////////////////////////////
+	/// \brief Get drawable width of the window
+	///
+	/// \returns Width of the window in pixels
+	///
+	/// \see http://wiki.libsdl.org/SDL_GL_GetDrawableSize
+	///
+	////////////////////////////////////////////////////////////
+	int GetDrawableWidth() const;
+
+	////////////////////////////////////////////////////////////
+	/// \brief Get drawable height of the window
+	///
+	/// \returns Height of the window in pixels
+	///
+	/// \see http://wiki.libsdl.org/SDL_GL_GetDrawableSize
+	///
+	////////////////////////////////////////////////////////////
+	int GetDrawableHeight() const;
+
+	////////////////////////////////////////////////////////////
 	/// \brief Set window title
 	///
 	/// \param[in] title New window title in UTF-8 encoding


### PR DESCRIPTION
Added GetDrawableWidth and GetDrawableHeight, these are needed to support HiDPI on Retina MBP and others.